### PR TITLE
Fix indentation after a var with the $

### DIFF
--- a/codemirror/stylus.js
+++ b/codemirror/stylus.js
@@ -315,7 +315,12 @@ CodeMirror.defineMode("stylus", function(config) {
       return pushContext(state, stream, "block", 0);
     }
     if (type == "variable-name") {
-      return pushContext(state, stream, "variableName");
+      if ((stream.indentation() == 0 && startOfLine(stream)) || wordIsBlock(firstWordOfLine(stream))) {
+        return pushContext(state, stream, "variableName");
+      }
+      else {
+        return pushContext(state, stream, "variableName", 0);
+      }
     }
     if (type == "=") {
       if (!endOfLine(stream) && !wordIsBlock(firstWordOfLine(stream))) {
@@ -437,10 +442,10 @@ CodeMirror.defineMode("stylus", function(config) {
            wordIsTag(firstWordOfLine(stream)))) {
         return pushContext(state, stream, "block");
       }
-      if (stream.string.match(/^-?[a-z][\w-\.\[\]\'\"]*\s*=/) ||
+      if (stream.string.match(/^[\$-]?[a-z][\w-\.\[\]\'\"]*\s*=/) ||
           stream.string.match(/^\s*(\(|\)|[0-9])/) ||
           stream.string.match(/^\s+[a-z][\w-]*\(/i) ||
-          stream.string.match(/^\s+-?[a-z]/i)) {
+          stream.string.match(/^\s+[\$-]?[a-z]/i)) {
         return pushContext(state, stream, "block", 0);
       }
       if (endOfLine(stream)) return pushContext(state, stream, "block");


### PR DESCRIPTION
For example:

``` stylus
v1 = $v2
  |new line

body
  color $c
    |new line
```
